### PR TITLE
Support building on windows

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -3,30 +3,41 @@ module.exports = ->
   @initConfig
     pkg: @file.readJSON 'package.json'
 
-    exec:
+    clean:
       nuke_main:
-        command: 'rm -rf ./components/*/'
+        src: ['components']
+    
+    exec:
       main_install:
-        command: './node_modules/.bin/component install'
+        command: 'node ./node_modules/component/bin/component install'
       main_build:
-        command: './node_modules/.bin/component build -u component-json,component-coffee -o assets/browser -n noflo-ui -c'
+        command: 'node ./node_modules/component/bin/component build -u component-json,component-coffee -o assets/browser -n noflo-ui -c'
       preview_deps:
         command: 'npm install'
         stdout: false
         stderr: false
         cwd: 'components/noflo-noflo-ui/preview'
       preview_install:
-        command: './node_modules/.bin/component install'
+        command: 'node ./node_modules/component/bin/component install'
         cwd: 'components/noflo-noflo-ui/preview'
       preview_build:
-        command: './node_modules/.bin/component build -u component-json,component-coffee -o ../../../assets/preview/browser -n noflo-ui-preview -c'
+        command: 'node ./node_modules/component/bin/component build -u component-json,component-coffee -o ../../../assets/preview/browser -n noflo-ui-preview -c'
         cwd: 'components/noflo-noflo-ui/preview'
+
+    copy:
       copy_index:
-        command: 'cp -R assets/browser/noflo-noflo-ui/* assets/'
+        files: [
+          cwd: 'assets/browser/noflo-noflo-ui/'
+          src: ['**']
+          dest: 'assets/'
+          expand: true
+        ]
 
   # Grunt plugins used for building
   @loadNpmTasks 'grunt-exec'
+  @loadNpmTasks 'grunt-contrib-clean'
+  @loadNpmTasks 'grunt-contrib-copy'
 
   # Our local tasks
-  @registerTask 'build', ['exec']
+  @registerTask 'build', ['clean', 'exec', 'copy']
   @registerTask 'default', ['build']

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "component-builder": "git://github.com/bergie/builder.js.git#patch-1",
     "component-json": "~0.1.4",
     "component-coffee": "~0.1.4",
-    "component": "~0.17.6"
+    "component": "~0.17.6",
+    "grunt-contrib-clean": "~0.5.0",
+    "grunt-contrib-copy": "~0.5.0"
   }
 }


### PR DESCRIPTION
The slashes and grunt-shell were being problematic on windows. This PR addresses this three ways:

* Use grunt-contrib-clean to handle nuking directories
* Use grunt-contrib-copy to handle file copy
* Shell to node to run the exec scripts for component

